### PR TITLE
Use a function to bind keys

### DIFF
--- a/vi-increment.zsh
+++ b/vi-increment.zsh
@@ -12,8 +12,11 @@ fi
 autoload -Uz .vi-increment{,::select-number}
 zle -N vi-increment .vi-increment
 zle -N vi-decrement .vi-increment
-local m
-for m in vicmd visual; do
-	bindkey -M "$m" '^a' vi-increment
-	bindkey -M "$m" '^x' vi-decrement
-done
+
+() {
+    local m
+    for m in vicmd visual; do
+        bindkey -M "$m" '^a' vi-increment
+        bindkey -M "$m" '^x' vi-decrement
+    done
+}


### PR DESCRIPTION
With `local m` executed outside of a function it prints `m=visual` on zsh startup, also doesn't seem like `local` works as intended outside a function - after shell startup I can access the `m` value which was set in vi-increment.zsh